### PR TITLE
upsertPackage optimization

### DIFF
--- a/pkg/assembler/backends/ent/backend/package.go
+++ b/pkg/assembler/backends/ent/backend/package.go
@@ -132,36 +132,66 @@ func (b *EntBackend) IngestPackageID(ctx context.Context, pkg model.PkgInputSpec
 // It is used in multiple places, so we extract it to a function.
 func upsertPackage(ctx context.Context, client *ent.Tx, pkg model.PkgInputSpec) (*ent.PackageVersion, error) {
 
-	_, err := client.PackageType.Create().
+	pkgID, err := client.PackageType.Create().
 		SetType(pkg.Type).
 		OnConflict(sql.ConflictColumns(packagetype.FieldType)).
 		DoNothing().
 		ID(ctx)
 	if err != nil {
 		if err != stdsql.ErrNoRows {
-			// return nil, errors.Wrap(err, "upsert package type (constraint error)")
 			return nil, errors.Wrap(err, "upsert package node")
+		}
+		pkgID, err = client.PackageType.Query().
+			Where(packagetype.TypeEQ(pkg.Type)).
+			OnlyID(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "get package type")
 		}
 	}
 
-	pkgID, err := client.PackageType.Query().Where(packagetype.TypeEQ(pkg.Type)).OnlyID(ctx)
+	nsID, err := client.PackageNamespace.Create().
+		SetPackageID(pkgID).
+		SetNamespace(valueOrDefault(pkg.Namespace, "")).
+		OnConflict(sql.ConflictColumns(packagenamespace.FieldNamespace, packagenamespace.FieldPackageID)).
+		DoNothing().
+		ID(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "get package type")
+		if err != stdsql.ErrNoRows {
+			return nil, errors.Wrap(err, "upsert package namespace")
+		}
+		nsID, err = client.PackageNamespace.Query().
+			Where(
+				packagenamespace.PackageIDEQ(pkgID),
+				packagenamespace.NamespaceEQ(valueOrDefault(pkg.Namespace, "")),
+			).
+			OnlyID(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "get package namespace")
+		}
 	}
 
-	nsID, err := client.PackageNamespace.Create().SetPackageID(pkgID).SetNamespace(valueOrDefault(pkg.Namespace, "")).
-		OnConflict(sql.ConflictColumns(packagenamespace.FieldNamespace, packagenamespace.FieldPackageID)).UpdateNewValues().ID(ctx)
+	nameID, err := client.PackageName.Create().
+		SetNamespaceID(nsID).
+		SetName(pkg.Name).
+		OnConflict(sql.ConflictColumns(packagename.FieldName, packagename.FieldNamespaceID)).
+		DoNothing().
+		ID(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "upsert package namespace")
+		if err != stdsql.ErrNoRows {
+			return nil, errors.Wrap(err, "upsert package name")
+		}
+		nameID, err = client.PackageName.Query().
+			Where(
+				packagename.NamespaceIDEQ(nsID),
+				packagename.NameEQ(pkg.Name),
+			).
+			OnlyID(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "get package name")
+		}
 	}
 
-	nameID, err := client.PackageName.Create().SetNamespaceID(nsID).SetName(pkg.Name).
-		OnConflict(sql.ConflictColumns(packagename.FieldName, packagename.FieldNamespaceID)).UpdateNewValues().ID(ctx)
-	if err != nil {
-		return nil, errors.Wrap(err, "upsert package name")
-	}
-
-	err = client.PackageVersion.Create().
+	id, err := client.PackageVersion.Create().
 		SetNameID(nameID).
 		SetNillableVersion(pkg.Version).
 		SetSubpath(ptrWithDefault(pkg.Subpath, "")).
@@ -174,14 +204,23 @@ func upsertPackage(ctx context.Context, client *ent.Tx, pkg model.PkgInputSpec) 
 			),
 		).
 		DoNothing().
-		Exec(ctx)
+		ID(ctx)
 	if err != nil {
 		if err != stdsql.ErrNoRows {
 			return nil, errors.Wrap(err, "upsert package version")
 		}
+		id, err = client.PackageVersion.Query().
+			Where(
+				packageversion.HashEQ(versionHashFromInputSpec(pkg)),
+				packageversion.NameIDEQ(nameID),
+			).
+			OnlyID(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "get package version")
+		}
 	}
 
-	pv, err := client.PackageVersion.Query().Where(packageVersionInputQuery(pkg)).
+	pv, err := client.PackageVersion.Query().Where(packageversion.ID(id)).
 		WithName(withPackageNameTree()).
 		Only(ctx)
 	if err != nil {

--- a/pkg/assembler/backends/ent/backend/package_test.go
+++ b/pkg/assembler/backends/ent/backend/package_test.go
@@ -91,11 +91,11 @@ func (s *Suite) Test_get_package_helpers() {
 		Subpath:   ptr("subpath"),
 	}
 
-	_, err := WithinTX(s.Ctx, s.Client, func(ctx context.Context) (*ent.PackageVersion, error) {
+	_, err := WithinTX(s.Ctx, s.Client, func(ctx context.Context) (*int, error) {
 		return upsertPackage(s.Ctx, ent.TxFromContext(ctx), p2Spec)
 	})
 	s.Require().NoError(err)
-	pkgVersionID, err := WithinTX(s.Ctx, s.Client, func(ctx context.Context) (*ent.PackageVersion, error) {
+	pkgVersionID, err := WithinTX(s.Ctx, s.Client, func(ctx context.Context) (*int, error) {
 		return upsertPackage(s.Ctx, ent.TxFromContext(ctx), p1Spec)
 	})
 	s.Require().NoError(err)
@@ -147,14 +147,14 @@ func (s *Suite) TestEmptyQualifiersPredicate() {
 		},
 	}
 
-	pkg, err := WithinTX(s.Ctx, s.Client, func(ctx context.Context) (*ent.PackageVersion, error) {
+	pkg, err := WithinTX(s.Ctx, s.Client, func(ctx context.Context) (*int, error) {
 		return upsertPackage(s.Ctx, ent.TxFromContext(ctx), spec)
 	})
 	s.Require().NoError(err)
 	s.Require().NotNil(pkg)
 
 	// Ingest twice to ensure upserts are working
-	pkg, err = WithinTX(s.Ctx, s.Client, func(ctx context.Context) (*ent.PackageVersion, error) {
+	pkg, err = WithinTX(s.Ctx, s.Client, func(ctx context.Context) (*int, error) {
 		return upsertPackage(s.Ctx, ent.TxFromContext(ctx), spec)
 	})
 	s.Require().NoError(err)
@@ -166,7 +166,7 @@ func (s *Suite) TestEmptyQualifiersPredicate() {
 
 	s.Run("No Qualifiers", func() {
 		spec.Qualifiers = nil
-		pkg, err := WithinTX(s.Ctx, s.Client, func(ctx context.Context) (*ent.PackageVersion, error) {
+		pkg, err := WithinTX(s.Ctx, s.Client, func(ctx context.Context) (*int, error) {
 			return upsertPackage(s.Ctx, ent.TxFromContext(ctx), spec)
 		})
 		s.Require().NoError(err)


### PR DESCRIPTION
# Description of the PR

- cherry-pick https://github.com/guacsec/guac/commit/5ebbc66534b3fd64059762431426d8bb6538e34b to have the latest upsert version for the `Package` endpoints as the baseline for changes
- the more relevant commit is 591ffffc4eb9827465ed51e755b71348494b1d5d where I changed the `upsertPackage` to return only `*int` instead of `*ent.PackageVersion` because the latter isn't required any more. In this way the "return ID" optimization [1] is done because the last query [2] can be safely removed

[1] https://github.com/guacsec/guac/issues/1116
[2]
```
	pv, err := client.PackageVersion.Query().Where(packageVersionInputQuery(pkg)).
		WithName(withPackageNameTree()).
		Only(ctx)
	if err != nil {
		return nil, errors.Wrap(err, "get package version")
	}
```

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
