### PR TITLE
Ent - TestIngestVulnerabilities changes to support ID

### DIFF
--- a/pkg/assembler/backends/ent/backend/vulnerability_test.go
+++ b/pkg/assembler/backends/ent/backend/vulnerability_test.go
@@ -19,7 +19,6 @@ package backend
 
 import (
 	"strconv"
-	"strings"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/internal/testing/ptrfrom"
@@ -336,15 +335,12 @@ func (s *Suite) TestIngestVulnerabilities() {
 	tests := []struct {
 		name    string
 		ingests []*model.VulnerabilityInputSpec
-		exp     []*string
+		exp     []string
 	}{{
 		name:    "Multiple",
 		ingests: []*model.VulnerabilityInputSpec{c1, c2, c3},
-		exp:     []*string{ptrfrom.String(""), ptrfrom.String(""), ptrfrom.String("")},
+		exp:     make([]string, 3),
 	}}
-	ignoreID := cmp.FilterPath(func(p cmp.Path) bool {
-		return strings.Compare(".ID", p[len(p)-1].String()) == 0
-	}, cmp.Ignore())
 	for _, test := range tests {
 		s.Run(test.name, func() {
 			ctx := s.Ctx
@@ -358,10 +354,8 @@ func (s *Suite) TestIngestVulnerabilities() {
 				t.Fatalf("ingest error: %v", err)
 				return
 			}
-			if len(got) != 3 {
-				if diff := cmp.Diff(test.exp, got, ignoreID); diff != "" {
-					t.Errorf("Unexpected results. (-want +got):\n%s", diff)
-				}
+			if diff := cmp.Diff(len(test.exp), len(got)); diff != "" {
+				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
# Description of the PR

`TestIngestVulnerabilities` enhanced to work with `IngestVulnerabilityIDs` response. 

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
